### PR TITLE
fixed sprint jump boost being applied when backward sprint jump is pa…

### DIFF
--- a/src/main/java/org/polyfrost/example/testmacro/caculator/functions/Player.java
+++ b/src/main/java/org/polyfrost/example/testmacro/caculator/functions/Player.java
@@ -86,6 +86,7 @@ public class Player extends Entity {
                 tickInput.setW(true);
             } else if (forward ==-1.0F) {
                 tickInput.setS(true);
+                sprinting = false;
             }
             if (strafing ==1.0F) {
                 tickInput.setA(true);


### PR DESCRIPTION
fixed sprint jump boost being applied when backward sprint jump is parsed with a negative duration argument like sj(-12).